### PR TITLE
Auto-detect GMP installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,5 +2,10 @@ cmake_minimum_required(VERSION 3.29)
 project(gmpwrap)
 
 set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
+find_package(GMP REQUIRED)
 
 add_library(gmpwrap SHARED gmpwrap.cpp gmpwrap.h)
+target_link_libraries(gmpwrap PUBLIC ${GMP_LIBRARIES})
+target_include_directories(gmpwrap PUBLIC ${GMP_INCLUDES} .)

--- a/cmake/FindGMP.cmake
+++ b/cmake/FindGMP.cmake
@@ -1,0 +1,18 @@
+# Try to find the GNU Multiple Precision Arithmetic Library (GMP)
+# See http://gmplib.org/
+# Taken from https://github.com/libigl/eigen/blob/master/cmake/FindGMP.cmake
+
+find_path(GMP_INCLUDES
+  NAMES
+  gmp.h
+  PATHS
+  $ENV{GMPDIR}
+  ${INCLUDE_INSTALL_DIR}
+)
+
+find_library(GMP_LIBRARIES gmp PATHS $ENV{GMPDIR} ${LIB_INSTALL_DIR})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GMP DEFAULT_MSG
+                                  GMP_INCLUDES GMP_LIBRARIES)
+mark_as_advanced(GMP_INCLUDES GMP_LIBRARIES)


### PR DESCRIPTION
This commit implements auto-detection of GMP installation directories using CMake standard find_package, along with a custom script to teach CMake how to find GMP specifically.

Then, this commit links gmpwrap with GMP itself, ensuring all the include files and linker steps work with GMP over many platforms.

This is the first of several commits towards building swisspair on macos.